### PR TITLE
Allow user selected window to return to

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -15,7 +15,7 @@
 	<!-- Actions -->
 	<string id="30100">Actions</string>
 	<string id="30101">Stop media</string>
-	<string id="30102">Return to Home</string>
+	<string id="30102">Return to</string>
 	<string id="30103">Wait for screensaver</string>
 
 	<!-- Dialogs -->

--- a/resources/lib/alarm.py
+++ b/resources/lib/alarm.py
@@ -65,9 +65,9 @@ class Alarm:
         if self.settings('actions.stopmedia') == 'true':
             logger.write('Stopping the current player')
             xbmc.executebuiltin('XBMC.PlayerControl(Stop)')
-        if self.settings('actions.returntohome') == 'true':
-            logger.write('Returning to the home window')
-            xbmc.executebuiltin('XBMC.ActivateWindow(Home)')
+        if self.settings('actions.returnto') != '':
+            logger.write('Returning to the {}'.format(self.settings('actions.returnto')))
+            xbmc.executebuiltin('XBMC.ActivateWindow({})'.format(self.settings('actions.returnto')))
         AlarmStore.unset(self.name)
 
     def set(self):

--- a/resources/lib/alarm.py
+++ b/resources/lib/alarm.py
@@ -59,15 +59,15 @@ class Alarm:
         self.language = xbmcaddon.Addon().getLocalizedString
 
     def _doAction(self):
+        if self.settings('actions.waitforscreensaver') == 'false':
+            logger.write('Executing CECStandby builtin')
+            xbmc.executebuiltin('XBMC.CECStandby')
         if self.settings('actions.stopmedia') == 'true':
             logger.write('Stopping the current player')
             xbmc.executebuiltin('XBMC.PlayerControl(Stop)')
         if self.settings('actions.returntohome') == 'true':
             logger.write('Returning to the home window')
             xbmc.executebuiltin('XBMC.ActivateWindow(Home)')
-        if self.settings('actions.waitforscreensaver') == 'false':
-            logger.write('Executing CECStandby builtin')
-            xbmc.executebuiltin('XBMC.CECStandby')
         AlarmStore.unset(self.name)
 
     def set(self):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,7 +9,7 @@
     </category>
     <category label="30100">
         <setting label="30101" type="bool" id="actions.stopmedia" default="true" />
-        <setting label="30102" type="bool" id="actions.returntohome" default="true" />
+        <setting label="30102" type="text" id="actions.returnto" default="home" />
         <setting label="30103" type="bool" id="actions.waitforscreensaver" default="true" />
     </category>
 </settings>


### PR DESCRIPTION
Allow the user to specify the window that should be returned to when the timer expires.  The specified window is entered in free text and can be any item specified by http://kodi.wiki/view/Window_IDs including skin or addon specific windows.