### PR TITLE
Fix error when setting reminder notification

### DIFF
--- a/resources/lib/alarm.py
+++ b/resources/lib/alarm.py
@@ -133,7 +133,7 @@ class Alarm(object):
             if ret:
                 logger.write('Alarm.set: {} created: {}'.format(self.name, ret))
                 if self.settings('notifications.duration') == 'true':
-                    if self.settings('notifications.duration.unit') == self.language(30040):
+                    if self.settings('notifications.duration.unit') == self.language(30040) or self.settings('notifications.duration.unit') == '':
                         rTimeout = timeout - (int(self.settings('notifications.duration.value')) * 60)
                     elif self.settings('notifications.duration.unit') == self.language(30041):
                         rTimeout = timeout - ((timeout * int(self.settings('notifications.duration.value'))) / 100)


### PR DESCRIPTION
Stemmed from having an empty value in the settings.xml - presumably due
to add-on setting refactor in Kodi main.  Now, if empty, default to item
with language id 30040 (Mins).